### PR TITLE
Fix the simultaneous user issue avoiding collisions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ run: clean compile
 
 # Compiles
 compile: src/Client/*.cpp
-	clang++ src/Client/*.cpp -I/Library/Frameworks/SDL2.framework/Headers -F/Library/Frameworks -framework SDL2 -o output/out
+	clang++ src/Client/*.cpp -I/Library/Frameworks/SDL2.framework/Headers -F/Library/Frameworks -framework SDL2 -g -o output/out
 
 # Removes compiled code inside output
 clean:
@@ -20,7 +20,7 @@ runS: cleanS compileS
 	output/server
 
 compileS:
-	g++ src/Server/*.cpp -w -o output/server
+	g++ src/Server/*.cpp -w -g -o output/server
 
 cleanS:
 	rm output/server

--- a/src/Client/Player.cpp
+++ b/src/Client/Player.cpp
@@ -63,7 +63,7 @@ int Player::sendPlayerData(bool inc, bool dec, float * angle, bool direction) {
     int server_address_len = sizeof(serv_addr);
 
     // Receieve response from server
-    int valread = recvfrom(socket_fd, &response, 1024, 0, (struct sockaddr *)&serv_addr, (socklen_t*)&server_address_len);
+    int valread = recvfrom(socket_fd, &response, sizeof(response), 0, (struct sockaddr *)&serv_addr, (socklen_t*)&server_address_len);
     //printf("Rec resp:\n x = %f\n y = %f\n", response.x, response.y);
     
     // Append response data to player object
@@ -98,25 +98,24 @@ int Player::getPlayerVector() {
         return -1;
     }
     
-    int decision = 0;
-    // Send ddecision data to server here
-    // This tells the server to process move data
+    int decision = 2;
+    // Send decision data to server here
+    // This tells the server to send other player data
     sendto(socket_fd, &decision, sizeof(decision), 0, (struct sockaddr *) &serv_addr, sizeof(serv_addr));
 
-    int testData = 12;
+    int testData = 69;
 
     sendto(socket_fd, &testData, sizeof(testData), 0, (struct sockaddr *) &serv_addr, sizeof(serv_addr));
 
     int server_address_len = sizeof(serv_addr);
 
-
     int rowsPlayerVect;
     // Get the number of rows to recv from server
-    int valread = recvfrom(socket_fd, &rowsPlayerVect, 1024, 0, (struct sockaddr *)&serv_addr, (socklen_t*)&server_address_len);
- 
+    int valread = recvfrom(socket_fd, &rowsPlayerVect, sizeof(rowsPlayerVect), 0, (struct sockaddr *)&serv_addr, (socklen_t*)&server_address_len);
+
+    
   
     for(int i=1; i<rowsPlayerVect; i++){
-        std::cout << "num of rows" << rowsPlayerVect << std::endl;
 
         struct Data pVrow;
     
@@ -136,8 +135,6 @@ int Player::getPlayerVector() {
         std::cout << "player ID: " << pVrow.id << "X: " << pVrow.x << "Y: " << pVrow.y << std::endl; 
  
     }
-//    for(int i=0; i<playerVector.size(); i++)
-//        std::cout << " rcvd other, players ids: " << playerVector[i].id << std::endl;
 
     close(socket_fd);
 

--- a/src/Client/main.cpp
+++ b/src/Client/main.cpp
@@ -58,6 +58,7 @@ int main(int argc, char const *argv[]) {
         return 1;
     }
 
+    int countFrame =0;
     // Runs the main game frames
     while (appIsRunning) {
 
@@ -69,8 +70,15 @@ int main(int argc, char const *argv[]) {
 
         // Handle movement of character
         mainChar.movePlayer(upArrowDown, downArrowDown, leftArrowDown, rightArrowDown);
-  
-        mainChar.getPlayerVector();
+       
+        // This is a workaround to fix the simultaneous players bug
+        // By running every N frames we reduce the chance of a collision
+        // by whatever N is in the below equation. This should be fixed.. 
+        // . . . eventually :)
+        if (countFrame % 20 == 0) {
+            mainChar.getPlayerVector();
+        } 
+        countFrame++;
 
         // Function to draw the 2d Map
         mapScreen.Map(renderer);

--- a/src/Server/movePlayer.cpp
+++ b/src/Server/movePlayer.cpp
@@ -104,9 +104,9 @@ void Player::movePlayer(int socket_fd, int addrlen) {
     }
 
     // To do (easy first bug): 
-    // Strange behaviour if you approach a wall on the wall's right
-    // side ( approaching from the left ) . I call it the "teleport
-    // you will move very quickly downward. This is probably due to
+    // Strange behaviour if you approach the left bounding 
+    // wall on the wall's right  . You will perform the "teleport" move
+    // ie: you will move very quickly downward. This is probably due to
     // you hitting one of the rules above and being moved.
     if(map[(y-1)*16 + x-1]==1) {
         //std::cout << x << "," << y << "left Bound" << std::endl;
@@ -148,24 +148,22 @@ void Player::movePlayer(int socket_fd, int addrlen) {
 
 void Player::sendPlayerVector(int socket_fd, int addrlen) {
 
-        std::cout << "running Server" << std::endl;
         int testData;
         int valread = recvfrom(socket_fd, &testData, sizeof(testData), MSG_WAITALL, (struct sockaddr *) &address, (socklen_t*) &addrlen);
 
-        std::cout << "rcvd data"<< testData << std::endl;
-
-        // Send player vector to client
+        // Initialize variables to send to client
         struct sockaddr_in client_address = *((struct sockaddr_in *)&address);
         int client_address_len = sizeof(client_address);
-
         int rowsPlayerVect = playerVector.size();
 
+        // Send # of rows of playerVector to client
+        // This can segfault because 2nd client can send an int
+        // When this is expecting a variable of type Data  
         sendto(socket_fd, &rowsPlayerVect, sizeof(rowsPlayerVect), 0, (struct sockaddr *)&client_address, client_address_len);
 
-
+    
+        // Loop through rows and send all of them to the client
         for(int i=1; i<playerVector.size(); i++){
-            std::cout << "sent data, playerVector ids: " << playerVector[i].id << std::endl;
-            
             // Initialize the playerVector row to send the data to the client
             struct Data pVrow;
             pVrow.id = i;
@@ -174,6 +172,6 @@ void Player::sendPlayerVector(int socket_fd, int addrlen) {
             pVrow.angle = playerVector[i].angle;
             sendto(socket_fd, &pVrow, sizeof(pVrow), 0, (struct sockaddr *)&client_address, client_address_len);
         }
-
+    
 }
 

--- a/src/Server/server.cpp
+++ b/src/Server/server.cpp
@@ -47,9 +47,8 @@ int main(int argc, char const *argv[]) {
             currentPlayer.movePlayer(socket_fd, addrlen);
             
         }
-        else{
+        else if(decision == 2){
             currentPlayer.sendPlayerVector(socket_fd,addrlen);
-            std::cout<< "checking other player moves" << std::endl; 
         }
     }
     return 0;


### PR DESCRIPTION
This bug is due to the fact that when another client joined the server there would be a packet collision. This would result in a segfault for the server and the player that was out of sync locking up because they would read something OOM. This was "solved" by not running this every frame but 1/20 frames. This is not ideal and will take a look at this in a future commit.